### PR TITLE
Enhance text-to-bitmap printing with Bangla support and printer stability improvements

### DIFF
--- a/android/src/main/java/com/reactnativeposprinter/TextToBitmapHandler.kt
+++ b/android/src/main/java/com/reactnativeposprinter/TextToBitmapHandler.kt
@@ -44,6 +44,11 @@ class TextToBitmapHandler(private val context: Context) {
             val escPosData = convertBitmapToEscPos(monoBitmap)
             outputStream.write(escPosData)
             outputStream.flush()
+            try {
+                Thread.sleep(30)
+            } catch (_: InterruptedException) {
+                // ignore
+            }
             true
         } catch (e: Exception) {
             Log.e(TAG, "Error printing text as bitmap", e)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-thermal-pos-printer",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "React Native thermal printer package for POS systems supporting Xprinter and other popular brands",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Fixed bitmap width to 384 dots (multiple of 8) for consistent rendering.
- Used ESC/POS raster command for chunked printing.
  - Updated TextToBitmapHandler.printTextAsBitmap:
  - Added short Thread.sleep to prevent printer overload.
  - Moved alignment extraction earlier to support fallback styles.
  - Introduced containsBangla helper to detect Bengali characters (U+0980–U+09FF).
  - Enforced bitmap rendering with a default sans-serif style when Bangla text is detected.
- Applied the same improvements for iOS implementation.