### PR TITLE
Improve bitmap printing and printer communication handling

### DIFF
--- a/android/src/main/java/com/reactnativeposprinter/EnhancedFontSizeHandler.kt
+++ b/android/src/main/java/com/reactnativeposprinter/EnhancedFontSizeHandler.kt
@@ -52,7 +52,7 @@ class EnhancedFontSizeHandler(private val context: Context) {
         
         return try {
             Log.d(TAG, "Printing text as bitmap - Size: ${getSizeDescription(fontSizePt)}, Letter spacing: $letterSpacing")
-            textToBitmapHandler.printTextAsBitmap(text, fontSizePt.toFloat(), outputStream, letterSpacing)
+            textToBitmapHandler.printTextAsBitmap(text, fontSizePt.toFloat(), outputStream, letterSpacing, appendLineFeed = true)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to print text with font: ${e.message}")
             false

--- a/android/src/main/java/com/reactnativeposprinter/TextToBitmapHandler.kt
+++ b/android/src/main/java/com/reactnativeposprinter/TextToBitmapHandler.kt
@@ -1,53 +1,70 @@
 package com.reactnativeposprinter
 
 import android.graphics.*
-import android.util.Log
-import android.util.TypedValue
-import java.io.OutputStream
-import java.io.ByteArrayOutputStream
+import android.text.StaticLayout
+import android.text.TextPaint
 import android.util.Base64
-import android.content.Context
+import android.util.Log
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 
-class TextToBitmapHandler(private val context: Context) {
-    
+class TextToBitmapHandler(private val context: android.content.Context) {
+
     companion object {
         private const val TAG = "TextToBitmap"
         private const val PRINTER_WIDTH_DOTS = 384
         private const val DEFAULT_PADDING = 4
-        private const val DEFAULT_LINE_SPACING = 1.2f
+        const val DEFAULT_LINE_SPACING = 1.0f
         private const val THRESHOLD_BASE = 128
-        private const val THRESHOLD_VARIANCE = 32
+        private const val PRINTER_DPI = 203
+        private const val BITMAP_FONT_SCALE = 0.85f
     }
-    
+
     data class TextStyle(
         val isBold: Boolean = false,
         val isItalic: Boolean = false,
         val isUnderline: Boolean = false,
         val isStrikethrough: Boolean = false,
         val fontFamily: String = "monospace",
-        val align: String = "left", 
+        val align: String = "left",
         val doubleWidth: Boolean = false,
         val doubleHeight: Boolean = false
     )
-    
+
     fun printTextAsBitmap(
         text: String,
         fontSizePt: Float,
         outputStream: OutputStream,
         letterSpacing: Float = 1.0f,
         lineSpacing: Float = DEFAULT_LINE_SPACING,
-        style: TextStyle = TextStyle()
+        style: TextStyle = TextStyle(),
+        scale: Float = BITMAP_FONT_SCALE,
+        appendLineFeed: Boolean = false
     ): Boolean {
         return try {
-            val bitmap = createTextBitmap(text, fontSizePt, letterSpacing, lineSpacing, style)
+            val bitmap = createTextBitmap(text, fontSizePt, letterSpacing, lineSpacing, style, scale)
             val monoBitmap = convertToMonochrome(bitmap)
             val escPosData = convertBitmapToEscPos(monoBitmap)
-            outputStream.write(escPosData)
-            outputStream.flush()
+            val total = escPosData.size
+            var offset = 0
+            val CHUNK_SIZE = 470
+            while (offset < total) {
+                val chunkLen = kotlin.math.min(CHUNK_SIZE, total - offset)
+                outputStream.write(escPosData, offset, chunkLen)
+                outputStream.flush()
+                try {
+                    Thread.sleep(20)
+                } catch (_: InterruptedException) {}
+                offset += chunkLen
+            }
+            if (appendLineFeed) {
+                try {
+                    outputStream.flush()
+                } catch (_: Exception) {}
+            }
             try {
-                Thread.sleep(30)
-            } catch (_: InterruptedException) {
-                // ignore
+                Thread.sleep(20)
+            } catch (_: InterruptedException) {}
             }
             true
         } catch (e: Exception) {
@@ -55,15 +72,16 @@ class TextToBitmapHandler(private val context: Context) {
             false
         }
     }
-    
+
     fun getTextAsBitmap64(
         text: String,
         fontSizePt: Float,
         letterSpacing: Float = 1.0f,
-        style: TextStyle = TextStyle()
+        style: TextStyle = TextStyle(),
+        scale: Float = BITMAP_FONT_SCALE
     ): String {
         return try {
-            val bitmap = createTextBitmap(text, fontSizePt, letterSpacing, DEFAULT_LINE_SPACING, style)
+            val bitmap = createTextBitmap(text, fontSizePt, letterSpacing, DEFAULT_LINE_SPACING, style, scale)
             val stream = ByteArrayOutputStream()
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
             Base64.encodeToString(stream.toByteArray(), Base64.DEFAULT)
@@ -72,59 +90,48 @@ class TextToBitmapHandler(private val context: Context) {
             ""
         }
     }
-    
+
     private fun createTextBitmap(
         text: String,
         fontSizePt: Float,
         letterSpacing: Float,
         lineSpacing: Float,
-        style: TextStyle
+        style: TextStyle,
+        scale: Float = BITMAP_FONT_SCALE
     ): Bitmap {
-        val fontSizePx = convertPtToPx(fontSizePt)
+        val fontSizePx = convertPtToPx(fontSizePt, scale)
         val paint = createPaint(fontSizePx, letterSpacing, style)
-        val actualTextWidth = paint.measureText(text)
-        var textHeight = (paint.textSize * lineSpacing).toInt()
-        
-        if (style.doubleWidth) {
-            paint.textScaleX = 2.0f
+        val textWidth = PRINTER_WIDTH_DOTS - (2 * DEFAULT_PADDING)
+        val textLayout = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            StaticLayout.Builder.obtain(text, 0, text.length, paint, textWidth)
+                .setAlignment(getLayoutAlignment(style.align))
+                .setLineSpacing(0f, lineSpacing)
+                .setIncludePad(true)
+                .build()
+        } else {
+            StaticLayout(text, paint, textWidth, getLayoutAlignment(style.align), lineSpacing, 0f, false)
         }
-        if (style.doubleHeight) {
-            textHeight *= 2
-            paint.textSize = fontSizePx * 2
-        }
-        
-        val bitmapWidth = PRINTER_WIDTH_DOTS
-        val bitmapHeight = textHeight + DEFAULT_PADDING * 2
-        val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        val bitmapHeight = textLayout.height + (2 * DEFAULT_PADDING)
+        val bitmap = Bitmap.createBitmap(PRINTER_WIDTH_DOTS, bitmapHeight, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        
         canvas.drawColor(Color.WHITE)
-        val availableWidth = bitmapWidth - (DEFAULT_PADDING * 2)
-        val finalTextWidth = if (style.doubleWidth) actualTextWidth * 2 else actualTextWidth
-        
-        val x = when (style.align.lowercase()) {
-            "center" -> {
-                val centerX = DEFAULT_PADDING + (availableWidth - finalTextWidth) / 2f
-                centerX
-            }
-            "right" -> {
-                val rightX = DEFAULT_PADDING + availableWidth - finalTextWidth
-                rightX
-            }
-            else -> {
-                DEFAULT_PADDING.toFloat()
-            }
-        }
-        
-        val fontMetrics = paint.fontMetrics
-        val y = DEFAULT_PADDING - fontMetrics.top
-        canvas.drawText(text, x, y, paint)
-        
+        canvas.save()
+        canvas.translate(DEFAULT_PADDING.toFloat(), DEFAULT_PADDING.toFloat())
+        textLayout.draw(canvas)
+        canvas.restore()
         return bitmap
     }
-    
-    private fun createPaint(fontSizePx: Float, letterSpacing: Float, style: TextStyle): Paint {
-        return Paint().apply {
+
+    private fun getLayoutAlignment(align: String): android.text.Layout.Alignment {
+        return when (align.lowercase()) {
+            "center" -> android.text.Layout.Alignment.ALIGN_CENTER
+            "right" -> android.text.Layout.Alignment.ALIGN_OPPOSITE
+            else -> android.text.Layout.Alignment.ALIGN_NORMAL
+        }
+    }
+
+    private fun createPaint(fontSizePx: Float, letterSpacing: Float, style: TextStyle): TextPaint {
+        return TextPaint().apply {
             textSize = fontSizePx
             color = Color.BLACK
             isAntiAlias = true
@@ -132,14 +139,13 @@ class TextToBitmapHandler(private val context: Context) {
             this.letterSpacing = letterSpacing - 1.0f
             isUnderlineText = style.isUnderline
             isStrikeThruText = style.isStrikethrough
-            
             if (style.isBold) {
                 strokeWidth = 1.5f
                 this.style = Paint.Style.FILL_AND_STROKE
             }
         }
     }
-    
+
     private fun createTypeface(style: TextStyle): Typeface {
         val baseTypeface = when (style.fontFamily.lowercase()) {
             "serif" -> Typeface.SERIF
@@ -147,46 +153,36 @@ class TextToBitmapHandler(private val context: Context) {
             "monospace" -> Typeface.MONOSPACE
             else -> Typeface.MONOSPACE
         }
-        
         val typefaceStyle = when {
             style.isBold && style.isItalic -> Typeface.BOLD_ITALIC
             style.isBold -> Typeface.BOLD
             style.isItalic -> Typeface.ITALIC
             else -> Typeface.NORMAL
         }
-        
         return Typeface.create(baseTypeface, typefaceStyle)
     }
-    
-    private fun convertPtToPx(pt: Float): Float {
-        return TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_PT,
-            pt,
-            context.resources.displayMetrics
-        )
+
+    private fun convertPtToPx(pt: Float, scale: Float = 1.0f): Float {
+        return pt * (PRINTER_DPI / 72f) * scale
     }
-    
+
     private fun convertBitmapToEscPos(bitmap: Bitmap): ByteArray {
         val monoBitmap = convertToMonochrome(bitmap)
         return convertBitmapToGSv(monoBitmap)
     }
-    
+
     private fun convertBitmapToGSv(bitmap: Bitmap): ByteArray {
         val outputStream = ByteArrayOutputStream()
-        val width = bitmap.width.coerceAtMost(384)
+        val width = bitmap.width.coerceAtMost(PRINTER_WIDTH_DOTS)
         val height = bitmap.height
-        val CHUNK_HEIGHT = 24 
+        val CHUNK_HEIGHT = 24
+        outputStream.write(byteArrayOf(0x1B, 0x40))
         
         for (startY in 0 until height step CHUNK_HEIGHT) {
             val endY = minOf(startY + CHUNK_HEIGHT, height)
             val chunkHeight = endY - startY
-            
-            outputStream.write(byteArrayOf(0x1B, 0x40))
-            outputStream.write(0x1D) 
-            outputStream.write(0x76)
-            outputStream.write(0x30)
-            outputStream.write(0x00)  
-            
+            outputStream.write(byteArrayOf(0x1D, 0x76, 0x30, 0x00))
+
             val widthBytes = (width + 7) / 8
             outputStream.write(widthBytes and 0xFF)
             outputStream.write((widthBytes shr 8) and 0xFF)
@@ -208,81 +204,27 @@ class TextToBitmapHandler(private val context: Context) {
                     outputStream.write(byte)
                 }
             }
-
-            Thread.sleep(20)
+            try {
+                Thread.sleep(30)
+            } catch (_: InterruptedException) {}
         }
-        
         return outputStream.toByteArray()
     }
 
     private fun convertToMonochrome(bitmap: Bitmap): Bitmap {
         val monoBitmap = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(monoBitmap)
-        
         val paint = Paint().apply {
-            colorFilter = ColorMatrixColorFilter(ColorMatrix().apply {
-                setSaturation(0f)
-            })
+            colorFilter = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
         }
-        
         canvas.drawBitmap(bitmap, 0f, 0f, paint)
-        
         val pixels = IntArray(bitmap.width * bitmap.height)
         monoBitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
-        
         for (i in pixels.indices) {
             val gray = Color.red(pixels[i])
             pixels[i] = if (gray < THRESHOLD_BASE) Color.BLACK else Color.WHITE
         }
-        
         monoBitmap.setPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
         return monoBitmap
-    }
-
-    private fun createMultiLineTextBitmap(
-        text: String,
-        fontSizePt: Float,
-        letterSpacing: Float,
-        lineSpacing: Float,
-        style: TextStyle
-    ): Bitmap {
-        val fontSizePx = convertPtToPx(fontSizePt)
-        val paint = createPaint(fontSizePx, letterSpacing, style)
-        
-        val lines = text.split("\n")
-        val lineHeight = (paint.textSize * lineSpacing).toInt()
-        val fontMetrics = paint.fontMetrics
-        
-        var maxWidth = 0
-        val lineWidths = mutableListOf<Int>()
-        
-        lines.forEach { line ->
-            val textBounds = Rect()
-            paint.getTextBounds(line, 0, line.length, textBounds)
-            val width = textBounds.width()
-            lineWidths.add(width)
-            maxWidth = maxOf(maxWidth, width)
-        }
-        
-        val bitmapWidth = minOf((maxWidth + DEFAULT_PADDING * 2), PRINTER_WIDTH_DOTS)
-        val bitmapHeight = (lines.size * lineHeight) + DEFAULT_PADDING * 2
-        
-        val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bitmap)
-        canvas.drawColor(Color.WHITE)
-        
-        lines.forEachIndexed { index, line ->
-            val lineWidth = lineWidths[index]
-            val x = when (style.align.lowercase()) {
-                "center" -> (bitmapWidth - lineWidth) / 2f
-                "right" -> bitmapWidth - lineWidth - DEFAULT_PADDING.toFloat()
-                else -> DEFAULT_PADDING.toFloat()
-            }
-            
-            val y = DEFAULT_PADDING.toFloat() + (index + 1) * lineHeight - fontMetrics.descent
-            canvas.drawText(line, x, y, paint)
-        }
-        
-        return bitmap
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-thermal-pos-printer",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "React Native thermal printer package for POS systems supporting Xprinter and other popular brands",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Switched from device DPI to printer DPI for accurate rendering.
- Replaced per-line bitmap writes with multi-line rendering 
  (supports both Bangla and non-Bangla via single bitmap).
- Added alignment command before bitmap printing for proper positioning.
- Implemented recovery INIT when bitmap printing fails.
- Updated writeDataToPrinter to:
  • Send data in 1KB chunks with pauses to prevent BLE buffer overflow.
  • Return success/failure status for reliable communication.